### PR TITLE
Fix EMAIL_USE_TLS and EMAIL_USE_SSL configurations quoting issue

### DIFF
--- a/charts/bugsink/templates/config-map.yaml
+++ b/charts/bugsink/templates/config-map.yaml
@@ -17,8 +17,8 @@ data:
   {{- with .Values.smtp.port }}
   EMAIL_PORT: {{ . | quote }}
   {{- end }}
-  EMAIL_USE_TLS: {{ ternary "True" "False" .Values.smtp.useTls }}
-  EMAIL_USE_SSL: {{ ternary "True" "False" .Values.smtp.useSsl }}
+  EMAIL_USE_TLS: {{ ternary "True" "False" .Values.smtp.useTls | quote }}
+  EMAIL_USE_SSL: {{ ternary "True" "False" .Values.smtp.useSsl | quote }}
   {{- with .Values.smtp.timeout }}
   EMAIL_TIMEOUT: {{ . | quote }}
   {{- end }}


### PR DESCRIPTION
When trying to use the built in configuration mechanism for SMTP like this:

```yaml
smtp:
  enabled: true
  useTls: false
  useSsl: true
```

The resulting config map will look like this:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: release-name-bugsink
  labels:
    helm.sh/chart: bugsink-0.1.0
    app.kubernetes.io/name: bugsink
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.5.4"
    app.kubernetes.io/managed-by: Helm
data:
  ALLOWED_HOSTS: "*"
  EMAIL_HOST: ""
  EMAIL_USE_TLS: False
  EMAIL_USE_SSL: True
```

Notice the missing quotes around the boolean values. This will fail to be deployed in Kubernetes as config map values need to be strings.