### PR TITLE
Fix template generation issue when secret key and admin secrets are both provided

### DIFF
--- a/charts/bugsink/templates/_helpers.tpl
+++ b/charts/bugsink/templates/_helpers.tpl
@@ -42,7 +42,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "bugsink.secret.create" }}
-{{- ternary true false (or (not .Values.secretKey.existingSecret) (and .Values.smtp.enabled (not .Values.smtp.existingSecret)) (not .Values.admin.existingSecret) (and .Values.externalDatabase.url (not .Values.externalDatabase.existingSecret)) .Values.extraEnv.secrets) }}
+{{- ternary true false (or (not .Values.secretKey.existingSecret) (and .Values.smtp.enabled (not .Values.smtp.existingSecret)) (not .Values.admin.existingSecret) (and .Values.externalDatabase.url (not .Values.externalDatabase.existingSecret)) (not (not .Values.extraEnv.secrets))) }}
 {{- end }}
 
 {{- define "bugsink.env" -}}


### PR DESCRIPTION
When both admin secret and secret key secret are provided like this:

```yaml
admin:
  existingSecret: "admin-secret"
secretKey:
  existingSecret: "secret-secret"
```

Rendering the chart will fail with this error:

```
Error: template: bugsink/templates/secret.yaml:1:8: executing "bugsink/templates/secret.yaml" at <include "bugsink.secret.create" .>: error calling include: template: bugsink/templates/_helpers.tpl:45:250: executing "bugsink.secret.create" at <.Values.extraEnv.secrets>: wrong type for value; expected bool; got map[string]interface {}
```