### PR TITLE
Fix: Add DATABASE_URL to the secrets

### DIFF
--- a/charts/bugsink/templates/secret.yaml
+++ b/charts/bugsink/templates/secret.yaml
@@ -13,6 +13,9 @@ stringData:
   EMAIL_HOST_USER: {{ .Values.smtp.username | quote }}
   EMAIL_HOST_PASSWORD: {{ .Values.smtp.password | quote }}
   {{- end }}
+  {{- if .Values.externalDatabase.url }}
+  DATABASE_URL: {{ .Values.externalDatabase.url | quote }}
+  {{- end }}
   {{- if not .Values.admin.existingSecret }}
   CREATE_SUPERUSER: {{ include "bugsink.admin.auth" . | quote }}
   {{- end }}


### PR DESCRIPTION
Without this PR, the value from 
```yaml
externalDatabase:
    url:
```
was never added to the secret, and thus never propagated to the pod, resulting in using the internal sqlite server.
