### PR TITLE
Fix bugsink.secret.create helper always evaluating to true

### DIFF
--- a/charts/bugsink/templates/_helpers.tpl
+++ b/charts/bugsink/templates/_helpers.tpl
@@ -41,9 +41,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- end }}
 {{- end }}
 
-{{- define "bugsink.secret.create" }}
-{{- ternary true false (or (not .Values.secretKey.existingSecret) (and .Values.smtp.enabled (not .Values.smtp.existingSecret)) (not .Values.admin.existingSecret) (and .Values.externalDatabase.url (not .Values.externalDatabase.existingSecret)) (not (not .Values.extraEnv.secrets))) }}
-{{- end }}
+{{- define "bugsink.secret.create" -}}
+{{- if or (not .Values.secretKey.existingSecret) (and .Values.smtp.enabled (not .Values.smtp.existingSecret)) (not .Values.admin.existingSecret) (and .Values.externalDatabase.url (not .Values.externalDatabase.existingSecret)) .Values.extraEnv.secrets -}}
+true
+{{- end -}}
+{{- end -}}
 
 {{- define "bugsink.env" -}}
 env:


### PR DESCRIPTION
Hi,

while deploying Bugsink in a Kubernetes cluster with strict policies that disallow Secret creation by default, I noticed that the chart always generates a Secret, even when all sensitive values are provided from existing Secrets. In most setups this is likely a cosmetic issue, but in my case it caused the deployment to fail.

The `bugsink.secret.create` helper in `templates/_helpers.tpl` used `ternary true false (...)` to signal whether the chart-managed Secret should be created. The problem is that `include` in Helm always returns a string, so both outcomes (boolean `true` and boolean `false`) become the strings `"true"` and `"false"` respectively. Since any non-empty string is truthy in a Helm `if` block, the condition `{{- if (include "bugsink.secret.create" .) }}` always evaluated to true, unconditionally rendering the Secret and the corresponding `envFrom.secretRef`.

The fix is to replace `ternary` with an `if`/`end` block that outputs `"true"` when the Secret should be created and nothing (empty string) otherwise. An empty string is falsy in Helm, which gives the helper the correct semantics. As a minor cleanup, the double negation `(not (not .Values.extraEnv.secrets))` is simplified to `.Values.extraEnv.secrets`.

To validate the fix, use `helm template`. With all existing Secret references configured, no chart-managed Secret or `envFrom.secretRef` should appear in the output:

```
helm template test charts/bugsink \
  --set secretKey.existingSecret=signing \
  --set secretKey.existingSecretKey=key \
  --set admin.existingSecret=admin \
  --set admin.existingSecretKey=auth \
  --set postgresql.enabled=false \
  --set externalDatabase.existingSecret=psqldb-bugsink-user-ddl-connection-secret \
  --set externalDatabase.existingSecretKey=connectionString
```