### PR TITLE
Add support for custom volumes and volumeMounts

### DIFF
--- a/charts/bugsink/templates/deployment.yaml
+++ b/charts/bugsink/templates/deployment.yaml
@@ -72,9 +72,13 @@ spec:
           {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:
-            {{ toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- include "bugsink.env" . | nindent 10 }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/bugsink/values.yaml
+++ b/charts/bugsink/values.yaml
@@ -229,3 +229,19 @@ extraEnv:
   # Existing secrets holding the environment variables.
   secretRefs: [ ]
   # - name: my-secret
+
+# Additional volumes to add to the Pod spec.
+volumes: []
+# - name: my-emptydir-volume
+#   emptyDir: {}
+# - name: my-configmap-volume
+#   configMap:
+#     name: my-configmap
+
+# Additional volume mounts to add to the container.
+volumeMounts: []
+# - name: my-emptydir-volume
+#   mountPath: /mnt/data
+# - name: my-configmap-volume
+#   mountPath: /etc/config
+#   readOnly: true


### PR DESCRIPTION
Users may need to mount additional volumes into the Bugsink container, for example to supply a CA certificate for TLS-verified database connections or custom configuration files via ConfigMaps. The chart had no way to attach arbitrary volumes.

Adds volumes and volumeMounts as empty-by-default values so existing deployments are unaffected. Also fixes an incorrect blank line in the volumeMounts template block caused by a missing leading dash on the toYaml delimiter.